### PR TITLE
fixes link to RailsTutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Recommended Books:
 
 * [EloquentJavascript](http://eloquentjavascript.net/)
 
-* [RailsTutorial](http://eloquentjavascript.net/)
+* [RailsTutorial](http://railstutorial.org/)
 
 Recommended Video Series:
 


### PR DESCRIPTION
the link originally pointed to eloquent javascript